### PR TITLE
SQleet #48 Crash on opening encrypted database files 

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class DbSQLiteAdapterConan(ConanFile):
 
 	def requirements(self):
 		self.requires("DbAdapterInterface/2.1.0@systelab/stable")
-		self.requires("sqleet/0.0.2@systelab/testing")
+		self.requires("sqleet/3.31.1-1@systelab/stable")
 
 		self.requires("gtest/1.14.0#4372c5aed2b4018ed9f9da3e218d18b3", private=True)
 		self.requires("DbAdapterTestUtilities/2.1.0@systelab/stable", private=True)

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class DbSQLiteAdapterConan(ConanFile):
 
 	def requirements(self):
 		self.requires("DbAdapterInterface/2.1.0@systelab/stable")
-		self.requires("sqleet/3.31.1-1@systelab/stable")
+		self.requires("sqleet/0.0.2@systelab/testing")
 
 		self.requires("gtest/1.14.0#4372c5aed2b4018ed9f9da3e218d18b3", private=True)
 		self.requires("DbAdapterTestUtilities/2.1.0@systelab/stable", private=True)

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class DbSQLiteAdapterConan(ConanFile):
 
 	def requirements(self):
 		self.requires("DbAdapterInterface/2.1.0@systelab/stable")
-		self.requires("sqleet/3.31.1@systelab/stable")
+		self.requires("sqleet/3.31.1-1@systelab/stable")
 
 		self.requires("gtest/1.14.0#4372c5aed2b4018ed9f9da3e218d18b3", private=True)
 		self.requires("DbAdapterTestUtilities/2.1.0@systelab/stable", private=True)


### PR DESCRIPTION
Update the SQleet version to fix the issur: https://github.com/resilar/sqleet/issues/48
Resolution on: Fix a problem in sqlite3CodecQueryParameters() that was introduced by the query parameter encoding changes for the 3.31.1 release (https://www.sqlite.org/src/info/cc65ca541265bd70)
