### PR TITLE
Obsolence: Replace SQLeet by sqlite3multipleciphers

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,11 @@ class DbSQLiteAdapterConan(ConanFile):
 		cmake = CMake(self)
 		cmake.configure(source_folder=".")
 		cmake.build()
-
+		
+	def imports(self):
+		dest = "bin/DbSQLiteAdapterTest/{}".format(str(self.settings.build_type))
+		self.copy("sqlite3mc.dll", dst=dest, src="bin", root_package="sqlite3mc")
+       
 	def package(self):
 		self.copy("*.h", dst="include/DbSQLiteAdapter", src="src/DbSQLiteAdapter")
 		self.copy("*DbSQLiteAdapter.lib", dst="lib", keep_path=False)

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,8 +25,7 @@ class DbSQLiteAdapterConan(ConanFile):
 		cmake.build()
 		
 	def imports(self):
-		dest = "bin/{}".format(str(self.settings.build_type))
-		self.copy("sqlite3mc.dll", dst=dest, src="bin", root_package="sqlite3mc")
+		self.copy("sqlite3mc.dll", dst=f"bin/{self.settings.build_type}", src="bin", root_package="sqlite3mc")
        
 	def package(self):
 		self.copy("*.h", dst="include/DbSQLiteAdapter", src="src/DbSQLiteAdapter")

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,7 +25,8 @@ class DbSQLiteAdapterConan(ConanFile):
 		cmake.build()
 		
 	def imports(self):
-		self.copy("sqlite3mc.dll", dst="bin", src="bin", root_package="sqlite3mc")
+		dest = "bin/{}".format(str(self.settings.build_type))
+		self.copy("sqlite3mc.dll", dst=dest, src="bin", root_package="sqlite3mc")
        
 	def package(self):
 		self.copy("*.h", dst="include/DbSQLiteAdapter", src="src/DbSQLiteAdapter")

--- a/conanfile.py
+++ b/conanfile.py
@@ -25,8 +25,7 @@ class DbSQLiteAdapterConan(ConanFile):
 		cmake.build()
 		
 	def imports(self):
-		dest = "bin/DbSQLiteAdapterTest/{}".format(str(self.settings.build_type))
-		self.copy("sqlite3mc.dll", dst=dest, src="bin", root_package="sqlite3mc")
+		self.copy("sqlite3mc.dll", dst="bin", src="bin", root_package="sqlite3mc")
        
 	def package(self):
 		self.copy("*.h", dst="include/DbSQLiteAdapter", src="src/DbSQLiteAdapter")

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class DbSQLiteAdapterConan(ConanFile):
 
 	def requirements(self):
 		self.requires("DbAdapterInterface/2.1.0@systelab/stable")
-		self.requires("sqleet/3.31.1-1@systelab/stable")
+		self.requires("sqlite3mc/2.3.0@systelab/testing")
 
 		self.requires("gtest/1.14.0#4372c5aed2b4018ed9f9da3e218d18b3", private=True)
 		self.requires("DbAdapterTestUtilities/2.1.0@systelab/stable", private=True)

--- a/src/DbSQLiteAdapter/CMakeLists.txt
+++ b/src/DbSQLiteAdapter/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.2)
 
 # Find external dependencides
 find_package(DbAdapterInterface)
-find_package(sqleet)
+find_package(sqlite3mc)
 
 # Configure preprocessor definitions
 add_compile_options(-DSQLITE_HAS_CODEC)
@@ -15,7 +15,7 @@ set(DB_SQLITE_ADAPTER DbSQLiteAdapter)
 file(GLOB_RECURSE DB_SQLITE_ADAPTER_SRC "*.cpp")
 file(GLOB_RECURSE DB_SQLITE_ADAPTER_HDR "*.h")
 add_library(${DB_SQLITE_ADAPTER} STATIC ${DB_SQLITE_ADAPTER_SRC} ${DB_SQLITE_ADAPTER_HDR})
-target_link_libraries(${DB_SQLITE_ADAPTER} sqleet::sqleet DbAdapterInterface::DbAdapterInterface)
+target_link_libraries(${DB_SQLITE_ADAPTER} sqlite3mc::sqlite3mc DbAdapterInterface::DbAdapterInterface)
 
 #Configure source groups
 foreach(FILE ${DB_SQLITE_ADAPTER_SRC} ${DB_SQLITE_ADAPTER_HDR}) 

--- a/src/DbSQLiteAdapter/Connection.cpp
+++ b/src/DbSQLiteAdapter/Connection.cpp
@@ -4,7 +4,7 @@
 
 #include <DbAdapterInterface/IConnectionConfiguration.h>
 
-#include <sqleet/sqleet.h>
+#include <sqlite3mc/sqlite3mc.h>
 
 namespace systelab { namespace db { namespace sqlite {
 

--- a/src/DbSQLiteAdapter/Connection.cpp
+++ b/src/DbSQLiteAdapter/Connection.cpp
@@ -37,6 +37,13 @@ namespace systelab { namespace db { namespace sqlite {
 				sqlite3_close(database);
 				throw SQLiteException("Invalid encryption key", extendedMessage, keyStatusCode, extendedErrorCode);
 			}
+
+			auto rc = sqlite3_exec(database, "SELECT 1;", nullptr, nullptr, nullptr);
+			if (rc != SQLITE_OK)
+			{
+				sqlite3_close(database);
+				throw SQLiteException("Database access denied", sqlite3_errmsg(database), rc, sqlite3_extended_errcode(database));
+			}
 		}
 
 		auto db = std::make_unique<Database>(database);

--- a/src/DbSQLiteAdapter/Connection.cpp
+++ b/src/DbSQLiteAdapter/Connection.cpp
@@ -26,6 +26,28 @@ namespace systelab { namespace db { namespace sqlite {
 			throw SQLiteException("Unable to open database file '" + filepath + "'", extendedMessage, openStatusCode, extendedErrorCode);
 		}
 
+		if (configuration.hasParameter("cipher"))
+		{
+			auto cipherName = configuration.getParameter("cipher");
+
+			// https://utelle.github.io/SQLite3MultipleCiphers/docs/configuration/config_capi/#description-of-configuration-functions
+			// Allowed cypher names: chacha20(default), aes128cbc, aes256cbc, sqlcipher, rc4, ascon128
+			int cipherIndex = sqlite3mc_cipher_index(cipherName.c_str());
+			if (cipherIndex == -1)
+			{
+				sqlite3_close(database);
+				throw SQLiteException("Invalid cipher '" + cipherName + "'", "", -1, -1);
+			}
+
+			// The return value always is the current parameter value on success, or -1 on failure.
+			int configCipherStatusCode = sqlite3mc_config(database, "cipher", cipherIndex);
+			if (configCipherStatusCode != cipherIndex)
+			{
+				sqlite3_close(database);
+				throw SQLiteException("Unable to configure cipher '" + cipherName + "'", sqlite3_errmsg(database), configCipherStatusCode, sqlite3_extended_errcode(database));
+			}
+		}
+
 		if (configuration.hasParameter("key"))
 		{
 			std::string key = configuration.getParameter("key");

--- a/src/DbSQLiteAdapter/ConnectionConfiguration.cpp
+++ b/src/DbSQLiteAdapter/ConnectionConfiguration.cpp
@@ -5,9 +5,11 @@
 namespace systelab { namespace db { namespace sqlite {
 
 	ConnectionConfiguration::ConnectionConfiguration(const std::string& filepath,
-													 const std::optional<std::string>& key)
+													 const std::optional<std::string>& key,
+													 const std::optional<std::string>& cipher)
 		:m_filepath(filepath)
 		,m_key(key)
+		,m_cipher(cipher)
 	{
 	}
 
@@ -22,6 +24,10 @@ namespace systelab { namespace db { namespace sqlite {
 		else if (parameterName == "key")
 		{
 			return m_key.has_value();
+		}
+		else if (parameterName == "cipher")
+		{
+			return m_cipher.has_value();
 		}
 		else
 		{
@@ -38,6 +44,10 @@ namespace systelab { namespace db { namespace sqlite {
 		else if (parameterName == "key" && m_key.has_value())
 		{
 			return *m_key;
+		}
+		else if (parameterName == "cipher" && m_cipher.has_value())
+		{
+			return *m_cipher;
 		}
 		else
 		{

--- a/src/DbSQLiteAdapter/ConnectionConfiguration.h
+++ b/src/DbSQLiteAdapter/ConnectionConfiguration.h
@@ -11,7 +11,8 @@ namespace systelab { namespace db { namespace sqlite {
 	{
 	public:
 		explicit ConnectionConfiguration(const std::string& filepath,
-								const std::optional<std::string>& key = std::nullopt);
+								const std::optional<std::string>& key = std::nullopt,
+								const std::optional<std::string>& cipher = std::nullopt);
 		~ConnectionConfiguration();
 
 		bool hasParameter(const std::string& name) const override;
@@ -20,6 +21,7 @@ namespace systelab { namespace db { namespace sqlite {
 	private:
 		std::string m_filepath;
 		std::optional<std::string> m_key;
+		std::optional<std::string> m_cipher;
 	};
 
 }}}

--- a/src/DbSQLiteAdapter/Database.cpp
+++ b/src/DbSQLiteAdapter/Database.cpp
@@ -6,11 +6,27 @@
 #include "RecordSet.h"
 #include "TableRecordSet.h"
 
+#include <algorithm>
+#include <cstring> 
 #include <iostream>
 #include <sqleet/sqleet.h>
 
 
 namespace systelab { namespace db { namespace sqlite {
+
+	namespace
+	{
+		inline char* relaxSyntax(const std::string& sql) 
+		{
+			std::string res {sql};
+			std::ranges::replace(res, '"', '\'');
+			
+			char* out = new char[res.size() + 1];
+			std::memcpy(out, res.c_str(), res.size() + 1); 
+			return out; 
+		}
+	}
+
 
 	Database::Database(sqlite3* database)
 		:m_database(database)
@@ -48,7 +64,7 @@ namespace systelab { namespace db { namespace sqlite {
 	{
 		sqlite3_stmt* statement = 0;
 		Database::Lock databaseLock(*this);
-		if(sqlite3_prepare_v2(m_database, query.c_str(), -1, &statement, 0) == SQLITE_OK)
+		if(sqlite3_prepare_v2(m_database, relaxSyntax(query), -1, &statement, 0) == SQLITE_OK)
 		{
 			return std::unique_ptr<IRecordSet>( new RecordSet(statement, allFieldsAsStrings) );
 		}
@@ -67,7 +83,7 @@ namespace systelab { namespace db { namespace sqlite {
 	{
 		sqlite3_stmt* statement = 0;
 		Database::Lock databaseLock(*this);
-		if(sqlite3_prepare_v2(m_database, query.c_str(), -1, &statement, 0) == SQLITE_OK)
+		if(sqlite3_prepare_v2(m_database, relaxSyntax(query), -1, &statement, 0) == SQLITE_OK)
 		{
 			return std::unique_ptr<ITableRecordSet>( new TableRecordSet(table, statement) );
 		}
@@ -86,7 +102,7 @@ namespace systelab { namespace db { namespace sqlite {
 	{
 		sqlite3_stmt* statement = 0;
 		Database::Lock databaseLock(*this);
-		if(sqlite3_prepare_v2(m_database, operation.c_str(), -1, &statement, 0) == SQLITE_OK)
+		if(sqlite3_prepare_v2(m_database, relaxSyntax(operation), -1, &statement, 0) == SQLITE_OK)
 		{
 			int res = sqlite3_step(statement);
 			sqlite3_finalize(statement);
@@ -119,7 +135,7 @@ namespace systelab { namespace db { namespace sqlite {
 	{
 		char* errors = NULL;
 		Database::Lock databaseLock(*this);
-		if(sqlite3_exec(m_database, statements.c_str(), NULL, NULL, &errors) != SQLITE_OK)
+		if(sqlite3_exec(m_database, relaxSyntax(statements), NULL, NULL, &errors) != SQLITE_OK)
 		{
 			std::ostringstream exceptionStream;
 			std::string sqlError = sqlite3_errmsg(m_database);

--- a/src/DbSQLiteAdapter/Database.cpp
+++ b/src/DbSQLiteAdapter/Database.cpp
@@ -23,6 +23,7 @@ namespace systelab { namespace db { namespace sqlite {
 	Database::~Database()
 	{
 		sqlite3_close(m_database);
+		sqlite3_shutdown();
 	}
 
 	Database::Lock::Lock(Database& db)

--- a/src/DbSQLiteAdapter/Database.cpp
+++ b/src/DbSQLiteAdapter/Database.cpp
@@ -9,24 +9,11 @@
 #include <algorithm>
 #include <cstring> 
 #include <iostream>
-#include <sqlite3mc/sqlite3mc.h>
+
+#include "sqlite3mc/sqlite3mc.h"
 
 
 namespace systelab { namespace db { namespace sqlite {
-
-	namespace
-	{
-		inline char* relaxSyntax(const std::string& sql) 
-		{
-			std::string res {sql};
-			std::ranges::replace(res, '"', '\'');
-			
-			char* out = new char[res.size() + 1];
-			std::memcpy(out, res.c_str(), res.size() + 1); 
-			return out; 
-		}
-	}
-
 
 	Database::Database(sqlite3* database)
 		:m_database(database)
@@ -64,7 +51,7 @@ namespace systelab { namespace db { namespace sqlite {
 	{
 		sqlite3_stmt* statement = 0;
 		Database::Lock databaseLock(*this);
-		if(sqlite3_prepare_v2(m_database, relaxSyntax(query), -1, &statement, 0) == SQLITE_OK)
+		if(sqlite3_prepare_v2(m_database, query.c_str(), -1, &statement, 0) == SQLITE_OK)
 		{
 			return std::unique_ptr<IRecordSet>( new RecordSet(statement, allFieldsAsStrings) );
 		}
@@ -83,7 +70,7 @@ namespace systelab { namespace db { namespace sqlite {
 	{
 		sqlite3_stmt* statement = 0;
 		Database::Lock databaseLock(*this);
-		if(sqlite3_prepare_v2(m_database, relaxSyntax(query), -1, &statement, 0) == SQLITE_OK)
+		if(sqlite3_prepare_v2(m_database, query.c_str(), -1, &statement, 0) == SQLITE_OK)
 		{
 			return std::unique_ptr<ITableRecordSet>( new TableRecordSet(table, statement) );
 		}
@@ -102,7 +89,7 @@ namespace systelab { namespace db { namespace sqlite {
 	{
 		sqlite3_stmt* statement = 0;
 		Database::Lock databaseLock(*this);
-		if(sqlite3_prepare_v2(m_database, relaxSyntax(operation), -1, &statement, 0) == SQLITE_OK)
+		if(sqlite3_prepare_v2(m_database, operation.c_str(), -1, &statement, 0) == SQLITE_OK)
 		{
 			int res = sqlite3_step(statement);
 			sqlite3_finalize(statement);
@@ -135,7 +122,7 @@ namespace systelab { namespace db { namespace sqlite {
 	{
 		char* errors = NULL;
 		Database::Lock databaseLock(*this);
-		if(sqlite3_exec(m_database, relaxSyntax(statements), NULL, NULL, &errors) != SQLITE_OK)
+		if(sqlite3_exec(m_database, statements.c_str(), NULL, NULL, &errors) != SQLITE_OK)
 		{
 			std::ostringstream exceptionStream;
 			std::string sqlError = sqlite3_errmsg(m_database);

--- a/src/DbSQLiteAdapter/Database.cpp
+++ b/src/DbSQLiteAdapter/Database.cpp
@@ -9,7 +9,7 @@
 #include <algorithm>
 #include <cstring> 
 #include <iostream>
-#include <sqleet/sqleet.h>
+#include <sqlite3mc/sqlite3mc.h>
 
 
 namespace systelab { namespace db { namespace sqlite {

--- a/src/DbSQLiteAdapter/Record.cpp
+++ b/src/DbSQLiteAdapter/Record.cpp
@@ -7,7 +7,7 @@
 
 #include "DbAdapterInterface/IRecordSet.h"
 
-#include <sqleet/sqleet.h>
+#include <sqlite3mc/sqlite3mc.h>
 
 
 namespace systelab { namespace db { namespace sqlite {

--- a/src/DbSQLiteAdapter/RecordSet.cpp
+++ b/src/DbSQLiteAdapter/RecordSet.cpp
@@ -5,7 +5,7 @@
 #include "Record.h"
 
 #include <DbAdapterInterface/IFieldValue.h>
-#include <sqleet/sqleet.h>
+#include <sqlite3mc/sqlite3mc.h>
 
 
 namespace systelab { namespace db { namespace sqlite {

--- a/src/DbSQLiteAdapter/Table.cpp
+++ b/src/DbSQLiteAdapter/Table.cpp
@@ -12,7 +12,7 @@
 #include <DbAdapterInterface/IRecord.h>
 #include <DbAdapterInterface/IRecordSet.h>
 
-#include <sqleet/sqleet.h>
+#include <sqlite3mc/sqlite3mc.h>
 
 
 namespace systelab { namespace db { namespace sqlite {

--- a/src/DbSQLiteAdapter/TableRecord.cpp
+++ b/src/DbSQLiteAdapter/TableRecord.cpp
@@ -7,7 +7,7 @@
 
 #include "DbAdapterInterface/ITableRecordSet.h"
 
-#include <sqleet/sqleet.h>
+#include <sqlite3mc/sqlite3mc.h>
 
 
 namespace systelab { namespace db { namespace sqlite {

--- a/src/DbSQLiteAdapter/TableRecordSet.cpp
+++ b/src/DbSQLiteAdapter/TableRecordSet.cpp
@@ -6,7 +6,7 @@
 
 #include "DbAdapterInterface/ITable.h"
 
-#include <sqleet/sqleet.h>
+#include <sqlite3mc/sqlite3mc.h>
 
 
 namespace systelab { namespace db { namespace sqlite {

--- a/test/DbSQLiteAdapterTest/Helpers/Helpers.cpp
+++ b/test/DbSQLiteAdapterTest/Helpers/Helpers.cpp
@@ -76,7 +76,7 @@ namespace systelab { namespace db { namespace sqlite { namespace unit_test {
 			oss << "INSERT INTO "+tableName_t1+" (ID, FIELD_INT, FIELD_STR) VALUES (" 
 				<< i 
 				<< ", " << i%4 
-				<< ", \"STR" << i%9 << "\""
+				<< ", 'STR" << i%9 << "'"
 				<< ")";
 			db.executeOperation(oss.str());
 		}
@@ -89,7 +89,7 @@ namespace systelab { namespace db { namespace sqlite { namespace unit_test {
 				<< i 
 				<< ", " << i%4 
 				<< ", " << i%20
-				<< ", \"STR" << i%9 << "\""
+				<< ", 'STR" << i%9 << "'"
 				<< ")";
 			db.executeOperation(oss.str());
 		}

--- a/test/DbSQLiteAdapterTest/Tests/DbConnectionTest.cpp
+++ b/test/DbSQLiteAdapterTest/Tests/DbConnectionTest.cpp
@@ -99,6 +99,14 @@ namespace systelab { namespace db { namespace sqlite { namespace unit_test {
 		ASSERT_NO_THROW(connection.loadDatabase(configuration));
 	}
 
+	// Happy path with encryption and not default cipher
+	TEST_F(DbConnectionTest, testLoadDatabaseForHappyPathWithCipherCreatesDBFile)
+	{
+		systelab::db::sqlite::ConnectionConfiguration configuration(m_dbFilePath.string(), "MyEncryptionKey"s, "ascon128"s);
+		systelab::db::sqlite::Connection connection;
+		auto database = connection.loadDatabase(configuration);
+		ASSERT_TRUE(std::filesystem::exists(m_dbFilePath));
+	}
 
 	// Error cases
 #ifdef _WIN32
@@ -126,6 +134,13 @@ namespace systelab { namespace db { namespace sqlite { namespace unit_test {
 		std::string invalidEncryptionKey = "InvalidEncryptionKey";
 		systelab::db::sqlite::ConnectionConfiguration invalidConfiguration(dbFilepath, invalidEncryptionKey);
 		ASSERT_THROW(connection.loadDatabase(invalidConfiguration), systelab::db::IConnection::Exception);
+	}
+
+	TEST_F(DbConnectionTest, testLoadDatabaseWithInvalidCypherNameThrowsException)
+	{
+		systelab::db::sqlite::ConnectionConfiguration invalidCypherNameConfiguration(m_dbFilePath.string(), "MyEncryptionKey", "NotExistentCypherName");
+		systelab::db::sqlite::Connection connection;
+		ASSERT_THROW(connection.loadDatabase(invalidCypherNameConfiguration), systelab::db::IConnection::Exception);
 	}
 
 }}}}

--- a/test/DbSQLiteAdapterTest/Tests/DbQueriesTest.cpp
+++ b/test/DbSQLiteAdapterTest/Tests/DbQueriesTest.cpp
@@ -4,10 +4,10 @@
 #include "DbSQLiteAdapter/ConnectionConfiguration.h"
 #include "DbSQLiteAdapter/DateTimeHelper.h"
 
-#include <DbAdapterInterface/IConnection.h>
-#include <DbAdapterTestUtilities/Mocks/MockConnection.h>
-#include <DbAdapterTestUtilities/Mocks/MockDatabase.h>
-#include <DbAdapterTestUtilities/Mocks/MockTable.h>
+#include "DbAdapterInterface/IConnection.h"
+#include "DbAdapterTestUtilities/Mocks/MockConnection.h"
+#include "DbAdapterTestUtilities/Mocks/MockDatabase.h"
+#include "DbAdapterTestUtilities/Mocks/MockTable.h"
 
 namespace systelab { namespace db { namespace sqlite { namespace unit_test {
 
@@ -70,8 +70,8 @@ namespace systelab { namespace db { namespace sqlite { namespace unit_test {
 					<< i 
 					<< ", " << i%7 
 					<< ", " << i%10 
-					<< ", \"STR" << i%9 << "\""
-					<< ", \"STR" << i%12 << "\""
+					<< ", 'STR" << i%9 << "'"
+					<< ", 'STR" << i%12 << "'"
 					<< ", '" << strDate << "'"
 					<< ")";
 				m_db->executeOperation(oss.str());


### PR DESCRIPTION
Under the 2026 Obsolence Plan, the sqleet component must be removed as no maintained, and their encryption algorithms are vulnerable.

Update cpp sqlite db adapter for replacing "sqleet/3.31.1-1" ( https://github.com/resilar/sqleet/issues/48) by SQLite3 Multiple Ciphers 2.3.0 (based on SQLite 3.52.0): https://github.com/utelle/SQLite3MultipleCiphers/releases

In order to facilitate the review and getting the most value from the minimal effort, NO refactoring, code updating or cleaning of any form has been applied
		